### PR TITLE
feat: integrate Cronet proxy and robust config apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This browser implements advanced network proxying and configuration management t
 
 ✅ **Accept-Language**: Configurable language preferences that match Chrome's format
 
-✅ **X-Requested-With Removal**: Complete elimination of the `X-Requested-With` header on all HTTP/HTTPS requests through network proxying
+✅ **X-Requested-With Removal**: Complete elimination of the `X-Requested-With` header on all HTTP/HTTPS requests through Cronet proxying
 
 ✅ **Standard Headers**: Proper `Accept`, `Cache-Control`, `Sec-Fetch-*` headers matching Chrome's behavior
 
@@ -22,11 +22,11 @@ This browser implements advanced network proxying and configuration management t
 
 ❌ **Sec-CH-UA* Client Hints**: These are controlled by Chromium engine and cannot be fully overridden in WebView
 
-❌ **TLS Extension Ordering**: WebView's underlying network stack determines TLS handshake details
+❌ **Sec-CH-UA* Client Hints**: Controlled by Chromium engine and expose WebView/Chromium rather than Chrome
 
-❌ **GREASE Randomness**: Chrome's random GREASE values are not replicable in WebView
+❌ **TLS Extension Ordering**: TLS fingerprints (JA3/JA4) depend on engine internals; Cronet improves parity but some differences remain
 
-❌ **HTTP/2 Frame Ordering**: Exact frame priority and ordering may differ
+❌ **HTTP/2 SETTINGS/GREASE**: Frame ordering and GREASE values may vary from Chrome
 
 ❌ **Request Body Proxying**: WebResourceRequest API doesn't expose POST/PUT request bodies
 
@@ -34,7 +34,7 @@ This browser implements advanced network proxying and configuration management t
 
 ### Network Proxy Layer (`NetworkProxy`)
 - Intercepts all HTTP/HTTPS requests via `shouldInterceptRequest`
-- Recreates requests with OkHttp using shared HTTP client (HTTP/2, connection pooling)
+- Recreates requests with Cronet when available (Brotli, Zstd, HTTP/2, QUIC) with OkHttp fallback
 - Strips X-Requested-With header completely
 - Maintains cookie consistency through CookieManager
 - Bypasses native schemes: `blob:`, `data:`, `file:`, `ws:`, `wss:`, `intent:`
@@ -148,7 +148,8 @@ Smart recreation triggers on changes to:
 
 ## Dependencies
 
-- **OkHttp 4.12.0**: HTTP client for network proxying
+- **Cronet Embedded**: Chromium networking stack with Brotli/Zstd, HTTP/2, and QUIC
+- **OkHttp 5.1.0**: Fallback HTTP client
 - **AndroidX WebKit**: Modern WebView APIs
 - **Kotlinx Coroutines**: Async operations
 - **Koin**: Dependency injection

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,6 +102,8 @@ dependencies {
     implementation(libs.koin.androidx.compose.v356)
     implementation(libs.okhttp)
     implementation(libs.logging.interceptor)
+    implementation(libs.cronet.embedded)
+    implementation(libs.play.services.cronet)
     implementation(libs.coil.compose)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)

--- a/app/src/main/java/com/testlabs/browser/di/CoreModule.kt
+++ b/app/src/main/java/com/testlabs/browser/di/CoreModule.kt
@@ -10,9 +10,10 @@ import com.testlabs.browser.ui.browser.ChromeUAProvider
 import com.testlabs.browser.ui.browser.DefaultDeviceInfoProvider
 import com.testlabs.browser.ui.browser.DeviceInfoProvider
 import com.testlabs.browser.ui.browser.JsCompatScriptProvider
-import com.testlabs.browser.ui.browser.NetworkProxy
 import com.testlabs.browser.ui.browser.UAProvider
 import com.testlabs.browser.ui.browser.VersionProvider
+import com.testlabs.browser.network.HttpStackFactory
+import com.testlabs.browser.ui.browser.NetworkProxy
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -26,5 +27,6 @@ public val coreModule: Module =
         single<UAProvider> { ChromeUAProvider(get()) }
         single<DeviceInfoProvider> { DefaultDeviceInfoProvider(androidContext()) }
         single { JsCompatScriptProvider(get()) }
-        single { NetworkProxy() }
+        single { HttpStackFactory.create(androidContext(), get()) }
+        single { NetworkProxy(get()) }
     }

--- a/app/src/main/java/com/testlabs/browser/network/CronetHttpStack.kt
+++ b/app/src/main/java/com/testlabs/browser/network/CronetHttpStack.kt
@@ -1,0 +1,68 @@
+package com.testlabs.browser.network
+
+import java.io.IOException
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.nio.ByteBuffer
+import java.util.concurrent.Executors
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.chromium.net.CronetEngine
+import org.chromium.net.CronetException
+import org.chromium.net.UrlRequest
+import org.chromium.net.UrlResponseInfo
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+public class CronetHttpStack(
+    private val engine: CronetEngine,
+) : HttpStack {
+    override val name: String = "Cronet"
+    private val executor = Executors.newCachedThreadPool()
+    override suspend fun execute(request: ProxyRequest): ProxyResponse = suspendCancellableCoroutine { cont ->
+        val input = PipedInputStream()
+        val output = PipedOutputStream(input)
+        val callback = object : UrlRequest.Callback() {
+            var status = 0
+            var reason = ""
+            var headers: Map<String, String> = emptyMap()
+            var redirects = 0
+            override fun onRedirectReceived(req: UrlRequest, info: UrlResponseInfo, newLocationUrl: String) {
+                if (redirects++ >= 10) {
+                    req.cancel()
+                    output.close()
+                    cont.resumeWithException(IOException("Too many redirects"))
+                } else req.followRedirect()
+            }
+            override fun onResponseStarted(req: UrlRequest, info: UrlResponseInfo) {
+                status = info.httpStatusCode
+                reason = info.httpStatusText ?: ""
+                headers = info.allHeaders
+                req.read(ByteBuffer.allocateDirect(32 * 1024))
+            }
+            override fun onReadCompleted(req: UrlRequest, info: UrlResponseInfo, buffer: ByteBuffer) {
+                buffer.flip()
+                val bytes = ByteArray(buffer.remaining())
+                buffer.get(bytes)
+                output.write(bytes)
+                buffer.clear()
+                req.read(buffer)
+            }
+            override fun onSucceeded(req: UrlRequest, info: UrlResponseInfo) {
+                output.close()
+                cont.resume(ProxyResponse(status, reason, headers, input))
+            }
+            override fun onFailed(req: UrlRequest, info: UrlResponseInfo?, error: CronetException) {
+                output.close()
+                cont.resumeWithException(IOException(error.message ?: "Cronet error"))
+            }
+            override fun onCanceled(req: UrlRequest, info: UrlResponseInfo?) {
+                output.close()
+                cont.resumeWithException(IOException("Request canceled"))
+            }
+        }
+        val builder = engine.newUrlRequestBuilder(request.url, callback, executor).setHttpMethod(request.method)
+        request.headers.forEach { (k, v) -> builder.addHeader(k, v) }
+        val urlRequest = builder.build()
+        urlRequest.start()
+    }
+}

--- a/app/src/main/java/com/testlabs/browser/network/HttpStack.kt
+++ b/app/src/main/java/com/testlabs/browser/network/HttpStack.kt
@@ -1,0 +1,22 @@
+package com.testlabs.browser.network
+
+import java.io.InputStream
+
+public data class ProxyRequest(
+    val url: String,
+    val method: String,
+    val headers: Map<String, String>,
+    val body: ByteArray? = null,
+)
+
+public data class ProxyResponse(
+    val statusCode: Int,
+    val reasonPhrase: String,
+    val headers: Map<String, String>,
+    val body: InputStream,
+)
+
+public interface HttpStack {
+    public val name: String
+    public suspend fun execute(request: ProxyRequest): ProxyResponse
+}

--- a/app/src/main/java/com/testlabs/browser/network/HttpStackFactory.kt
+++ b/app/src/main/java/com/testlabs/browser/network/HttpStackFactory.kt
@@ -1,0 +1,40 @@
+package com.testlabs.browser.network
+
+import android.content.Context
+import com.google.android.gms.net.CronetProviderInstaller
+import com.google.android.gms.tasks.Tasks
+import com.testlabs.browser.ui.browser.UAProvider
+import org.chromium.net.CronetEngine
+
+public object HttpStackFactory {
+    public fun create(context: Context, uaProvider: UAProvider): HttpStack {
+        val engine = buildCronet(context, uaProvider.userAgent(desktop = false))
+        return if (engine != null) CronetHttpStack(engine) else OkHttpStack()
+    }
+    private fun buildCronet(context: Context, ua: String): CronetEngine? {
+        return try {
+            CronetEngine.Builder(context)
+                .enableHttp2(true)
+                .enableQuic(true)
+                .enableBrotli(true)
+                .enableZstd(true)
+                .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_IN_MEMORY, 10 * 1024 * 1024)
+                .setUserAgent(ua)
+                .build()
+        } catch (e: Throwable) {
+            try {
+                Tasks.await(CronetProviderInstaller.installProvider(context))
+                CronetEngine.Builder(context)
+                    .enableHttp2(true)
+                    .enableQuic(true)
+                    .enableBrotli(true)
+                    .enableZstd(true)
+                    .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_IN_MEMORY, 10 * 1024 * 1024)
+                    .setUserAgent(ua)
+                    .build()
+            } catch (_: Throwable) {
+                null
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/testlabs/browser/network/OkHttpStack.kt
+++ b/app/src/main/java/com/testlabs/browser/network/OkHttpStack.kt
@@ -1,0 +1,58 @@
+package com.testlabs.browser.network
+
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+private val hopHeaders = setOf(
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+)
+
+public class OkHttpStack : HttpStack {
+    override val name: String = "OkHttp"
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .followRedirects(false)
+        .followSslRedirects(false)
+        .build()
+    override suspend fun execute(request: ProxyRequest): ProxyResponse {
+        var current = buildRequest(request)
+        var count = 0
+        while (true) {
+            val response = client.newCall(current).execute()
+            when (response.code) {
+                301, 302, 303, 307, 308 -> {
+                    val location = response.header("Location") ?: throw IOException("Redirect without Location")
+                    response.close()
+                    if (++count > 10) throw IOException("Too many redirects")
+                    val url = current.url.resolve(location) ?: throw IOException("Bad redirect $location")
+                    current = current.newBuilder().url(url).build()
+                }
+                else -> {
+                    val headers = mutableMapOf<String, String>()
+                    response.headers.forEach { name, value ->
+                        if (name.lowercase() !in hopHeaders) headers[name] = value
+                    }
+                    val reason = response.message.ifBlank { "OK" }
+                    return ProxyResponse(response.code, reason, headers, response.body.byteStream())
+                }
+            }
+        }
+    }
+    private fun buildRequest(req: ProxyRequest): Request {
+        val builder = Request.Builder().url(req.url).method(req.method, req.body?.toRequestBody())
+        req.headers.forEach { (k, v) -> builder.header(k, v) }
+        return builder.build()
+    }
+}

--- a/app/src/main/java/com/testlabs/browser/presentation/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/testlabs/browser/presentation/browser/BrowserViewModel.kt
@@ -47,7 +47,7 @@ public class BrowserViewModel(
 
             _state.value = newState
 
-            if (intent is BrowserIntent.ApplySettings) {
+            if (intent is BrowserIntent.ApplySettings || intent is BrowserIntent.ApplySettingsAndRestart) {
                 settingsRepository.save(newState.settingsCurrent)
             }
 

--- a/app/src/main/java/com/testlabs/browser/ui/browser/NetworkProxy.kt
+++ b/app/src/main/java/com/testlabs/browser/ui/browser/NetworkProxy.kt
@@ -1,290 +1,105 @@
 package com.testlabs.browser.ui.browser
 
-import android.util.Log
 import android.webkit.CookieManager
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
+import com.testlabs.browser.network.HttpStack
+import com.testlabs.browser.network.ProxyRequest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.Response
-import java.io.IOException
-import java.net.HttpURLConnection
-import java.util.concurrent.TimeUnit
 
-private const val TAG = "NetworkProxy"
-private const val MAX_REDIRECTS = 10
+private val hopHeaders = setOf(
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+)
 
-/**
- * Network proxy that intercepts WebView requests and recreates them with OkHttp,
- * ensuring X-Requested-With header is absent and all other headers match Chrome.
- */
 public class NetworkProxy(
-    private val cookieManager: CookieManager = CookieManager.getInstance()
+    private val stack: HttpStack,
+    private val cookieManager: CookieManager = CookieManager.getInstance(),
 ) {
-
-    private val httpClient = OkHttpClient.Builder()
-        .connectTimeout(30, TimeUnit.SECONDS)
-        .readTimeout(30, TimeUnit.SECONDS)
-        .writeTimeout(30, TimeUnit.SECONDS)
-        .followRedirects(false) // We handle redirects manually
-        .followSslRedirects(false)
-        .build()
-
-    /**
-     * Intercepts a WebView request and proxies it through OkHttp if enabled and applicable.
-     * Returns null for schemes that should be handled natively by WebView.
-     */
-    public fun interceptRequest(
-        request: WebResourceRequest,
-        userAgent: String,
-        acceptLanguage: String,
-        proxyEnabled: Boolean
-    ): WebResourceResponse? {
+    public val stackName: String get() = stack.name
+    public fun interceptRequest(request: WebResourceRequest, userAgent: String, acceptLanguage: String, proxyEnabled: Boolean): WebResourceResponse? {
         val url = request.url.toString()
-
-        // Skip proxy for specific schemes that must remain native
-        if (!proxyEnabled || !shouldProxy(url)) {
-            return null
-        }
-
+        if (!proxyEnabled || !shouldProxy(url)) return null
         return try {
             runBlocking(Dispatchers.IO) {
-                proxyRequest(request, userAgent, acceptLanguage)
+                val headers = buildHeaders(request, userAgent, acceptLanguage)
+                val proxyRequest = ProxyRequest(url, request.method, headers)
+                val response = stack.execute(proxyRequest)
+                handleCookies(url, response.headers)
+                createWebResourceResponse(response)
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Proxy request failed for $url", e)
             createErrorResponse(e)
         }
     }
-
     private fun shouldProxy(url: String): Boolean {
         val scheme = url.substringBefore(':').lowercase()
-        return when (scheme) {
-            "http", "https" -> true
-            "blob", "data", "file", "ws", "wss", "intent", "chrome", "chrome-extension" -> false
-            else -> false
-        }
+        return scheme == "http" || scheme == "https"
     }
-
-    private fun proxyRequest(
-        webRequest: WebResourceRequest,
-        userAgent: String,
-        acceptLanguage: String
-    ): WebResourceResponse {
-        val url = webRequest.url.toString()
-        val httpUrl = url.toHttpUrlOrNull()
-            ?: throw IllegalArgumentException("Invalid URL: $url")
-
-        // Build OkHttp request with all necessary headers
-        val requestBuilder = Request.Builder()
-            .url(httpUrl)
-            .method(webRequest.method, createRequestBody())
-
-        // Add standard headers, ensuring X-Requested-With is NEVER included
-        addStandardHeaders(requestBuilder, webRequest, userAgent, acceptLanguage)
-
-        val response = executeWithRedirects(requestBuilder.build())
-        return convertToWebResourceResponse(response, url)
+    private fun buildHeaders(request: WebResourceRequest, userAgent: String, acceptLanguage: String): Map<String, String> {
+        val headers = mutableMapOf<String, String>()
+        headers["User-Agent"] = userAgent
+        if (request.isForMainFrame) headers["Accept-Language"] = acceptLanguage
+        request.requestHeaders.forEach { (name, value) ->
+            val lower = name.lowercase()
+            if (lower !in hopHeaders && lower != "user-agent" && lower != "accept-language" && lower != "x-requested-with") {
+                headers[name] = value
+            }
+        }
+        cookieManager.getCookie(request.url.toString())?.let { headers["Cookie"] = it }
+        return headers
     }
-
-    private fun createRequestBody(): okhttp3.RequestBody? {
-        // WebResourceRequest doesn't expose the request body in Android WebView API
-        // This is a known limitation - we can only handle GET requests properly
-        // For POST/PUT requests, the body would need to be captured at a higher level
-        return null
+    private fun handleCookies(url: String, headers: Map<String, String>) {
+        headers.filter { it.key.equals("Set-Cookie", true) }.forEach { cookieManager.setCookie(url, it.value) }
     }
-
-    private fun addStandardHeaders(
-        builder: Request.Builder,
-        webRequest: WebResourceRequest,
-        userAgent: String,
-        acceptLanguage: String
-    ) {
-        // Add User-Agent
-        builder.header("User-Agent", userAgent)
-
-        // Add Accept-Language
-        builder.header("Accept-Language", acceptLanguage)
-
-        // Add standard Accept headers based on request type
-        val url = webRequest.url.toString()
-        when {
-            webRequest.requestHeaders["Accept"] != null -> {
-                builder.header("Accept", webRequest.requestHeaders["Accept"]!!)
-            }
-            url.contains("css") -> {
-                builder.header("Accept", "text/css,*/*;q=0.1")
-            }
-            url.contains("js") -> {
-                builder.header("Accept", "*/*")
-            }
-            webRequest.isForMainFrame -> {
-                builder.header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8")
-            }
-            else -> {
-                builder.header("Accept", "*/*")
-            }
-        }
-
-        // Copy other headers from original request, EXCLUDING X-Requested-With
-        webRequest.requestHeaders.forEach { (name, value) ->
-            when (name.lowercase()) {
-                "x-requested-with" -> {
-                    // EXPLICITLY SKIP - this is the whole point
-                    Log.d(TAG, "Skipping X-Requested-With header")
-                }
-                "user-agent", "accept-language", "accept" -> {
-                    // Already handled above
-                }
-                "host" -> {
-                    // Let OkHttp handle Host header
-                }
-                else -> {
-                    builder.header(name, value)
-                }
-            }
-        }
-
-        // Add cookies for this domain
-        cookieManager.getCookie(webRequest.url.toString())?.let { cookies ->
-            builder.header("Cookie", cookies)
-        }
-
-        // Add cache control
-        builder.header("Cache-Control", "no-cache")
-
-        // Add standard Chrome headers
-        builder.header("Sec-Fetch-Site", "none")
-        builder.header("Sec-Fetch-Mode", "navigate")
-        builder.header("Sec-Fetch-User", "?1")
-        builder.header("Sec-Fetch-Dest", if (webRequest.isForMainFrame) "document" else "empty")
+    private fun createWebResourceResponse(response: com.testlabs.browser.network.ProxyResponse): WebResourceResponse {
+        val contentType = response.headers["Content-Type"] ?: "text/html"
+        val mime = contentType.substringBefore(';').trim()
+        val encoding = if (contentType.contains("charset=", true)) contentType.substringAfter("charset=", "UTF-8").trim() else "UTF-8"
+        val filtered = response.headers.filterKeys { it.lowercase() !in hopHeaders && !it.equals("content-type", true) }
+        val reason = response.reasonPhrase.ifBlank { defaultReason(response.statusCode) }
+        return WebResourceResponse(mime, encoding, response.statusCode, reason, filtered, response.body)
     }
-
-    private fun executeWithRedirects(request: Request): Response {
-        var currentRequest = request
-        var redirectCount = 0
-
-        while (redirectCount < MAX_REDIRECTS) {
-            val response = httpClient.newCall(currentRequest).execute()
-
-            when (response.code) {
-                HttpURLConnection.HTTP_MOVED_PERM,
-                HttpURLConnection.HTTP_MOVED_TEMP,
-                HttpURLConnection.HTTP_SEE_OTHER,
-                307, 308 -> {
-                    val location = response.header("Location")
-                    response.close()
-
-                    if (location == null) {
-                        throw IOException("Redirect without Location header")
-                    }
-
-                    val newUrl = currentRequest.url.resolve(location)
-                        ?: throw IOException("Invalid redirect URL: $location")
-
-                    currentRequest = currentRequest.newBuilder()
-                        .url(newUrl)
-                        .build()
-
-                    redirectCount++
-                }
-                else -> return response
-            }
-        }
-
-        throw IOException("Too many redirects")
+    private fun defaultReason(code: Int): String = when (code) {
+        200 -> "OK"
+        201 -> "Created"
+        202 -> "Accepted"
+        204 -> "No Content"
+        301 -> "Moved Permanently"
+        302 -> "Found"
+        303 -> "See Other"
+        307 -> "Temporary Redirect"
+        308 -> "Permanent Redirect"
+        400 -> "Bad Request"
+        401 -> "Unauthorized"
+        403 -> "Forbidden"
+        404 -> "Not Found"
+        405 -> "Method Not Allowed"
+        408 -> "Request Timeout"
+        409 -> "Conflict"
+        410 -> "Gone"
+        429 -> "Too Many Requests"
+        500 -> "Internal Server Error"
+        501 -> "Not Implemented"
+        502 -> "Bad Gateway"
+        503 -> "Service Unavailable"
+        504 -> "Gateway Timeout"
+        else -> "Unknown"
     }
-
-    private fun convertToWebResourceResponse(response: Response, originalUrl: String): WebResourceResponse {
-        // Store cookies
-        response.headers.values("Set-Cookie").forEach { cookie ->
-            cookieManager.setCookie(originalUrl, cookie)
-        }
-
-        // Determine MIME type and encoding
-        val contentType = response.header("Content-Type") ?: "text/html"
-        val mimeType = contentType.substringBefore(';').trim()
-        val encoding = if (contentType.contains("charset=", ignoreCase = true)) {
-            contentType.substringAfter("charset=", "UTF-8").trim()
-        } else "UTF-8"
-
-        // Convert headers (excluding hop-by-hop headers)
-        val responseHeaders = mutableMapOf<String, String>()
-        response.headers.forEach { (name, value) ->
-            when (name.lowercase()) {
-                "connection", "keep-alive", "proxy-authenticate",
-                "proxy-authorization", "te", "trailers", "transfer-encoding", "upgrade" -> {
-                    // Skip hop-by-hop headers
-                }
-                else -> responseHeaders[name] = value
-            }
-        }
-
-        // Get the input stream - this will be automatically closed when WebView is done with it
-        val inputStream = response.body.byteStream()
-
-        // Ensure we have a non-empty reason phrase for WebResourceResponse
-        val reasonPhrase = response.message.takeIf { it.isNotBlank() } ?: getDefaultReasonPhrase(response.code)
-
-        return WebResourceResponse(
-            mimeType,
-            encoding,
-            response.code,
-            reasonPhrase,
-            responseHeaders,
-            inputStream
-        )
-    }
-
-    private fun getDefaultReasonPhrase(statusCode: Int): String {
-        return when (statusCode) {
-            200 -> "OK"
-            201 -> "Created"
-            202 -> "Accepted"
-            204 -> "No Content"
-            301 -> "Moved Permanently"
-            302 -> "Found"
-            304 -> "Not Modified"
-            400 -> "Bad Request"
-            401 -> "Unauthorized"
-            403 -> "Forbidden"
-            404 -> "Not Found"
-            405 -> "Method Not Allowed"
-            408 -> "Request Timeout"
-            409 -> "Conflict"
-            410 -> "Gone"
-            429 -> "Too Many Requests"
-            500 -> "Internal Server Error"
-            501 -> "Not Implemented"
-            502 -> "Bad Gateway"
-            503 -> "Service Unavailable"
-            504 -> "Gateway Timeout"
-            else -> "Unknown"
-        }
-    }
-
     private fun createErrorResponse(error: Exception): WebResourceResponse {
-        val errorHtml = """
+        val html = """
             <!DOCTYPE html>
-            <html>
-            <head><title>Network Error</title></head>
-            <body>
-                <h1>Network Error</h1>
-                <p>Failed to load resource: ${error.message}</p>
-            </body>
+            <html><head><title>Network Error</title></head>
+            <body><h1>Network Error</h1><p>${error.message}</p></body>
             </html>
-        """.trimIndent()
-
-        return WebResourceResponse(
-            "text/html",
-            "UTF-8",
-            500,
-            "Internal Server Error",
-            emptyMap(),
-            errorHtml.byteInputStream()
-        )
+        """.trimIndent().byteInputStream()
+        return WebResourceResponse("text/html", "UTF-8", 500, "Internal Server Error", emptyMap(), html)
     }
 }

--- a/app/src/main/java/com/testlabs/browser/ui/browser/WebViewHost.kt
+++ b/app/src/main/java/com/testlabs/browser/ui/browser/WebViewHost.kt
@@ -32,6 +32,7 @@ import androidx.webkit.ServiceWorkerClientCompat
 import androidx.webkit.ServiceWorkerControllerCompat
 import androidx.webkit.WebSettingsCompat
 import com.testlabs.browser.domain.settings.WebViewConfig
+import org.koin.compose.koinInject
 private const val TAG = "WebViewHost"
 private const val MIME_TYPE_GUESS = "application/octet-stream"
 
@@ -115,6 +116,11 @@ public interface WebViewController {
      * Returns the current `X-Requested-With` header suppression mode detected for this engine.
      */
     public fun requestedWithHeaderMode(): RequestedWithHeaderMode
+
+    /**
+     * Returns the name of the active proxy stack.
+     */
+    public fun proxyStackName(): String
 }
 
 
@@ -156,7 +162,7 @@ public fun WebViewHost(
     val context = LocalContext.current
     val downloadHandler = remember { DownloadHandler(context) }
     val fileUploadHandler = remember { FileUploadHandler(context) }
-    val networkProxy = remember { NetworkProxy() }
+    val networkProxy: NetworkProxy = koinInject()
 
     var latestConfig by remember { mutableStateOf(config) }
     var webViewKey by remember { mutableIntStateOf(0) }
@@ -217,6 +223,7 @@ public fun WebViewHost(
                     }
                 }
                 override fun requestedWithHeaderMode(): RequestedWithHeaderMode = requestedWithHeaderModeOf(webView)
+                override fun proxyStackName(): String = networkProxy.stackName
             }
         onControllerReady(controller)
         onDispose {

--- a/app/src/main/java/com/testlabs/browser/ui/browser/components/BrowserSettingsDialog.kt
+++ b/app/src/main/java/com/testlabs/browser/ui/browser/components/BrowserSettingsDialog.kt
@@ -49,6 +49,7 @@ public fun BrowserSettingsDialog(
     headerMode: String,
     jsCompatEnabled: Boolean,
     onCopyDiagnostics: () -> Unit,
+    proxyStack: String,
 ) {
     var tempConfig by remember { mutableStateOf(config) }
     val hasChanges = tempConfig != config
@@ -166,7 +167,7 @@ public fun BrowserSettingsDialog(
 
                         Column {
                             SettingRow(
-                                label = "Route traffic via proxy",
+                                label = stringResource(id = R.string.settings_proxy_toggle),
                                 checked = tempConfig.proxyEnabled,
                                 onCheckedChange = { tempConfig = tempConfig.copy(proxyEnabled = it) }
                             )
@@ -231,11 +232,11 @@ public fun BrowserSettingsDialog(
                             }
                         }
 
-                        DiagnosticItem("User Agent", userAgent)
-                        DiagnosticItem("Accept-Language", acceptLanguages)
-                        DiagnosticItem("X-Requested-With Mode", headerMode)
-                        DiagnosticItem("JS Compatibility", if (jsCompatEnabled) "Enabled" else "Disabled")
-                        DiagnosticItem("Proxy Status", if (tempConfig.proxyEnabled) "Active" else "Disabled")
+                        DiagnosticItem(stringResource(id = R.string.settings_user_agent_label), userAgent)
+                        DiagnosticItem(stringResource(id = R.string.settings_accept_language_label), acceptLanguages)
+                        DiagnosticItem(stringResource(id = R.string.settings_header_mode_label), headerMode)
+                        DiagnosticItem(stringResource(id = R.string.settings_js_compat_status), if (jsCompatEnabled) "Enabled" else "Disabled")
+                        DiagnosticItem(stringResource(id = R.string.settings_proxy_stack), proxyStack)
                     }
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,8 @@
   <string name="settings_header_mode_label">X-Requested-With header mode</string>
   <string name="settings_js_compat_status">JS compatibility layer</string>
   <string name="settings_copy_diagnostics">Copy diagnostics</string>
+  <string name="settings_proxy_toggle">Route traffic via Chromium (Cronet)</string>
+  <string name="settings_proxy_stack">Proxy Stack</string>
   <string name="start_page_title">Fingerprint Test Launcher</string>
   <string name="start_page_subtitle">Choose a recommended page to begin fingerprint parity evaluation.</string>
   <string name="start_page_scan_title">BrowserScan</string>

--- a/docs/verification/fingerprintjs_summary.md
+++ b/docs/verification/fingerprintjs_summary.md
@@ -1,0 +1,3 @@
+| Key | Value |
+| --- | ----- |
+| note | Populate with summary from fingerprintjs.github.io/fingerprintjs |

--- a/docs/verification/httpbin_headers_app.json
+++ b/docs/verification/httpbin_headers_app.json
@@ -1,0 +1,3 @@
+{
+  "note": "Populate with output from httpbin.org/headers via app"
+}

--- a/docs/verification/tls_peet_chrome.json
+++ b/docs/verification/tls_peet_chrome.json
@@ -1,0 +1,3 @@
+{
+  "note": "Populate with output from tls.peet.ws/api/all via Chrome"
+}

--- a/docs/verification/tls_peet_webview.json
+++ b/docs/verification/tls_peet_webview.json
@@ -1,0 +1,3 @@
+{
+  "note": "Populate with output from tls.peet.ws/api/all via app"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,8 @@ turbine-version = "1.2.1"
 datastore = "1.1.7"
 kotlinx-serialization-json = "1.9.0"
 webkit = "1.14.0"
+cronet = "119.6045.31"
+play-services-cronet = "18.0.1"
 
 [libraries]
 # AndroidX Core
@@ -73,6 +75,8 @@ logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", ver
 mockk-v1145 = { module = "io.mockk:mockk", version.ref = "mockk-version" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 turbine-v121 = { module = "app.cash.turbine:turbine", version.ref = "turbine-version" }
+cronet-embedded = { module = "org.chromium.net:cronet-embedded", version.ref = "cronet" }
+play-services-cronet = { module = "com.google.android.gms:play-services-cronet", version.ref = "play-services-cronet" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- replace OkHttp proxy with Cronet-based HttpStack and OkHttp fallback
- ensure settings persistence and restart reloads current page
- document Chrome parity limits and add verification placeholders

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb244ac8f08325977a8b694bd09a94