### PR TITLE
feat: add Chrome UA provider and apply full WebView config

### DIFF
--- a/app/src/main/java/com/testlabs/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/testlabs/browser/di/BrowserModule.kt
@@ -1,14 +1,14 @@
-/**
- * Author: Lorenzo Suarez
- * Date: 09/06/2025
- */
 package com.testlabs.browser.di
 
 import com.testlabs.browser.presentation.browser.BrowserViewModel
+import com.testlabs.browser.ui.browser.AndroidVersionProvider
+import com.testlabs.browser.ui.browser.ChromeUAProvider
 import com.testlabs.browser.ui.browser.JsCompatScriptProvider
 import com.testlabs.browser.ui.browser.NetworkProxy
 import com.testlabs.browser.ui.browser.UAProvider
+import com.testlabs.browser.ui.browser.VersionProvider
 import com.testlabs.browser.ui.browser.DefaultNetworkProxy
+import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
@@ -16,18 +16,9 @@ import org.koin.dsl.module
 public val browserModule: Module = module {
     viewModelOf(constructor = ::BrowserViewModel)
 
-    single<UAProvider> {
-        object : UAProvider {
-            override fun userAgent(desktop: Boolean): String {
-                val chromeVersion = "120.0.0.0"
-                return if (desktop) {
-                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/$chromeVersion Safari/537.36"
-                } else {
-                    "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/$chromeVersion Mobile Safari/537.36"
-                }
-            }
-        }
-    }
+    single<VersionProvider> { AndroidVersionProvider(androidContext()) }
+
+    single<UAProvider> { ChromeUAProvider(get()) }
 
     single<JsCompatScriptProvider> {
         object : JsCompatScriptProvider {

--- a/app/src/main/java/com/testlabs/browser/ui/browser/AndroidVersionProvider.kt
+++ b/app/src/main/java/com/testlabs/browser/ui/browser/AndroidVersionProvider.kt
@@ -1,0 +1,32 @@
+package com.testlabs.browser.ui.browser
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+
+/**
+ * Retrieves version information from the Android system and installed Chrome/WebView packages.
+ */
+public class AndroidVersionProvider(private val context: Context) : VersionProvider {
+    override fun androidVersion(): String = Build.VERSION.RELEASE ?: "0"
+
+    override fun chromeFullVersion(): String {
+        // Prefer the installed Chrome version. Fall back to WebView implementation.
+        val chrome = packageVersion("com.android.chrome")
+        if (chrome != null) return chrome
+        return packageVersion("com.google.android.webview") ?: "0.0.0.0"
+    }
+
+    override fun chromeMajor(): Int = chromeFullVersion().substringBefore('.').toIntOrNull() ?: 0
+
+    override fun deviceModel(): String = Build.MODEL ?: "Android"
+
+    private fun packageVersion(pkg: String): String? {
+        return try {
+            val info = context.packageManager.getPackageInfo(pkg, 0)
+            info.versionName
+        } catch (_: PackageManager.NameNotFoundException) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/testlabs/browser/ui/browser/ChromeUAProvider.kt
+++ b/app/src/main/java/com/testlabs/browser/ui/browser/ChromeUAProvider.kt
@@ -1,0 +1,26 @@
+package com.testlabs.browser.ui.browser
+
+/**
+ * [UAProvider] implementation that mimics Chrome's User-Agent format.
+ * It never includes the "Android WebView" token to avoid exposing the host.
+ */
+public class ChromeUAProvider(
+    private val versionProvider: VersionProvider
+) : UAProvider {
+
+    override fun userAgent(desktop: Boolean): String {
+        val chromeVersion = versionProvider.chromeFullVersion()
+        val androidVersion = versionProvider.androidVersion()
+        val model = versionProvider.deviceModel()
+
+        return if (desktop) {
+            // Desktop mode pretends to be Chrome on Linux x86_64 similar to Chrome's device emulation.
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) " +
+                "Chrome/$chromeVersion Safari/537.36"
+        } else {
+            // Mobile mode mirrors Chrome for Android on a device.
+            "Mozilla/5.0 (Linux; Android $androidVersion; $model) " +
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/$chromeVersion Mobile Safari/537.36"
+        }
+    }
+}

--- a/app/src/main/java/com/testlabs/browser/ui/browser/VersionProvider.kt
+++ b/app/src/main/java/com/testlabs/browser/ui/browser/VersionProvider.kt
@@ -1,0 +1,18 @@
+package com.testlabs.browser.ui.browser
+
+/**
+ * Provides version information required to construct User-Agent strings.
+ */
+public interface VersionProvider {
+    /** Android OS version string, e.g. "14". */
+    public fun androidVersion(): String
+
+    /** Full Chrome version string, e.g. "123.0.6312.99". */
+    public fun chromeFullVersion(): String
+
+    /** Major Chrome version number extracted from [chromeFullVersion]. */
+    public fun chromeMajor(): Int
+
+    /** Device model reported in the UA string. */
+    public fun deviceModel(): String
+}

--- a/app/src/main/java/com/testlabs/browser/ui/browser/WebViewHost.kt
+++ b/app/src/main/java/com/testlabs/browser/ui/browser/WebViewHost.kt
@@ -206,6 +206,7 @@ private fun WebView.applyConfig(
 
     s.javaScriptEnabled = config.javascriptEnabled
     s.domStorageEnabled = config.domStorageEnabled
+    s.databaseEnabled = true
     s.allowFileAccess = config.fileAccessEnabled
     s.allowContentAccess = config.fileAccessEnabled
     s.mediaPlaybackRequiresUserGesture = !config.mediaAutoplayEnabled
@@ -214,6 +215,10 @@ private fun WebView.applyConfig(
     } else {
         WebSettings.MIXED_CONTENT_NEVER_ALLOW
     }
+    s.setSupportMultipleWindows(true)
+    s.javaScriptCanOpenWindowsAutomatically = true
+    s.useWideViewPort = true
+    s.loadWithOverviewMode = true
 
     val ua = config.customUserAgent ?: uaProvider.userAgent(desktop = config.desktopMode)
     s.userAgentString = ua
@@ -355,6 +360,7 @@ private fun applyFullWebViewConfiguration(
 
     s.javaScriptEnabled = config.javascriptEnabled
     s.domStorageEnabled = config.domStorageEnabled
+    s.databaseEnabled = true
     s.allowFileAccess = config.fileAccessEnabled
     s.allowContentAccess = config.fileAccessEnabled
     s.mediaPlaybackRequiresUserGesture = !config.mediaAutoplayEnabled
@@ -363,6 +369,10 @@ private fun applyFullWebViewConfiguration(
     } else {
         WebSettings.MIXED_CONTENT_NEVER_ALLOW
     }
+    s.setSupportMultipleWindows(true)
+    s.javaScriptCanOpenWindowsAutomatically = true
+    s.useWideViewPort = true
+    s.loadWithOverviewMode = true
 
     val cookieManager = CookieManager.getInstance()
     cookieManager.setAcceptCookie(true)


### PR DESCRIPTION
## Summary
- provide ChromeUAProvider driven by VersionProvider and AndroidVersionProvider
- wire UA provider via Koin module
- apply full WebView settings for configuration parity

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew ktlintCheck` *(fails: code style violations in AndroidTest source set)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8ba55768832596527d3da4e3ae6a