### PR TITLE
Align networking with Chrome

### DIFF
--- a/app/src/main/java/com/testlabs/browser/data/settings/BrowserSettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/testlabs/browser/data/settings/BrowserSettingsRepositoryImpl.kt
@@ -14,6 +14,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import com.testlabs.browser.domain.settings.AcceptLanguageMode
 import com.testlabs.browser.domain.settings.BrowserSettingsRepository
 import com.testlabs.browser.domain.settings.WebViewConfig
+import com.testlabs.browser.domain.settings.EngineMode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -39,6 +40,8 @@ public class BrowserSettingsRepositoryImpl(
         val FORCE_DARK_MODE = booleanPreferencesKey("force_dark_mode")
         val PROXY_ENABLED = booleanPreferencesKey("proxy_enabled")
         val PROXY_INTERCEPT_ENABLED = booleanPreferencesKey("proxy_intercept_enabled")
+        val SUPPRESS_X_REQUESTED_WITH = booleanPreferencesKey("suppress_x_requested_with")
+        val ENGINE_MODE = stringPreferencesKey("engine_mode")
     }
 
     override val config: Flow<WebViewConfig> = dataStore.data.map { preferences ->
@@ -59,6 +62,8 @@ public class BrowserSettingsRepositoryImpl(
             forceDarkMode = preferences[PreferenceKeys.FORCE_DARK_MODE] ?: false,
             proxyEnabled = preferences[PreferenceKeys.PROXY_ENABLED] ?: true,
             proxyInterceptEnabled = preferences[PreferenceKeys.PROXY_INTERCEPT_ENABLED] ?: true,
+            suppressXRequestedWith = preferences[PreferenceKeys.SUPPRESS_X_REQUESTED_WITH] ?: true,
+            engineMode = preferences[PreferenceKeys.ENGINE_MODE]?.let { EngineMode.valueOf(it) } ?: EngineMode.Cronet,
         )
     }
 
@@ -78,6 +83,8 @@ public class BrowserSettingsRepositoryImpl(
             preferences[PreferenceKeys.FORCE_DARK_MODE] = config.forceDarkMode
             preferences[PreferenceKeys.PROXY_ENABLED] = config.proxyEnabled
             preferences[PreferenceKeys.PROXY_INTERCEPT_ENABLED] = config.proxyInterceptEnabled
+            preferences[PreferenceKeys.SUPPRESS_X_REQUESTED_WITH] = config.suppressXRequestedWith
+            preferences[PreferenceKeys.ENGINE_MODE] = config.engineMode.name
         }
     }
 

--- a/app/src/main/java/com/testlabs/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/testlabs/browser/di/BrowserModule.kt
@@ -8,6 +8,7 @@ import com.testlabs.browser.ui.browser.NetworkProxy
 import com.testlabs.browser.ui.browser.UAProvider
 import com.testlabs.browser.ui.browser.VersionProvider
 import com.testlabs.browser.ui.browser.DefaultNetworkProxy
+import com.testlabs.browser.domain.settings.WebViewConfig
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModelOf
@@ -26,5 +27,7 @@ public val browserModule: Module = module {
         }
     }
 
-    single<NetworkProxy> { DefaultNetworkProxy() }
+    factory<NetworkProxy> { (config: WebViewConfig) ->
+        DefaultNetworkProxy(androidContext(), config, get(), get())
+    }
 }

--- a/app/src/main/java/com/testlabs/browser/di/CoreModule.kt
+++ b/app/src/main/java/com/testlabs/browser/di/CoreModule.kt
@@ -9,6 +9,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import com.testlabs.browser.settings.DeveloperSettings
+import com.testlabs.browser.network.UserAgentClientHintsManager
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -18,4 +19,5 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(na
 public val coreModule: Module = module {
     single { androidContext().dataStore }
     single { DeveloperSettings() }
+    single { UserAgentClientHintsManager(androidContext()) }
 }

--- a/app/src/main/java/com/testlabs/browser/domain/settings/WebViewConfig.kt
+++ b/app/src/main/java/com/testlabs/browser/domain/settings/WebViewConfig.kt
@@ -29,9 +29,16 @@ public data class WebViewConfig(
     val forceDarkMode: Boolean = false,
     val proxyEnabled: Boolean = true,
     val proxyInterceptEnabled: Boolean = true,
+    val suppressXRequestedWith: Boolean = true,
+    val engineMode: EngineMode = EngineMode.Cronet,
 )
 
 public enum class AcceptLanguageMode {
     Baseline,
     DeviceList
+}
+
+public enum class EngineMode {
+    Cronet,
+    OkHttp
 }

--- a/app/src/main/java/com/testlabs/browser/network/CronetHolder.kt
+++ b/app/src/main/java/com/testlabs/browser/network/CronetHolder.kt
@@ -55,7 +55,7 @@ public object CronetHolder {
         fun createBuilder(): CronetEngine.Builder {
             return CronetEngine.Builder(context)
                 .enableHttp2(true)
-                .enableQuic(true)  
+                .enableQuic(false)
                 .enableBrotli(true)
                 .apply {
                     

--- a/app/src/main/java/com/testlabs/browser/network/HttpStackFactory.kt
+++ b/app/src/main/java/com/testlabs/browser/network/HttpStackFactory.kt
@@ -23,16 +23,17 @@ public object HttpStackFactory {
     public fun create(
         context: Context,
         settings: DeveloperSettings,
-        uaProvider: UAProvider
+        uaProvider: UAProvider,
+        chManager: UserAgentClientHintsManager
     ): HttpStack {
         return if (settings.useCronet.value) {
             val builder = CronetEngine.Builder(context)
             if (settings.enableQuic.value) builder.enableQuic(true)
             builder.enableHttp2(true)
             val engine = builder.build()
-            CronetHttpStack(engine, uaProvider)
+            CronetHttpStack(engine, uaProvider, chManager)
         } else {
-            OkHttpStack(uaProvider)
+            OkHttpStack(uaProvider, chManager)
         }
     }
 }

--- a/app/src/main/java/com/testlabs/browser/network/UserAgentClientHintsManager.kt
+++ b/app/src/main/java/com/testlabs/browser/network/UserAgentClientHintsManager.kt
@@ -40,6 +40,19 @@ public class UserAgentClientHintsManager(private val context: Context) {
     }
 
     /**
+     * Returns the default low-entropy UA-CH headers that mimic Chrome Mobile.
+     * The provided [majorVersion] must match the major version used in the User-Agent string.
+     */
+    public fun lowEntropyUaHints(majorVersion: String): Map<String, String> {
+        val ua = "\"Not;A=Brand\";v=\"99\", \"Google Chrome\";v=\"$majorVersion\", \"Chromium\";v=\"$majorVersion\""
+        return mapOf(
+            "sec-ch-ua" to ua,
+            "sec-ch-ua-mobile" to "?1",
+            "sec-ch-ua-platform" to "\"Android\""
+        )
+    }
+
+    /**
      * Check if a high-entropy hint is allowed for the given origin
      */
     public suspend fun isHighEntropyAllowed(origin: String, hintName: String): Boolean {

--- a/app/src/main/java/com/testlabs/browser/ui/browser/NetworkProxy.kt
+++ b/app/src/main/java/com/testlabs/browser/ui/browser/NetworkProxy.kt
@@ -4,8 +4,19 @@
  */
 package com.testlabs.browser.ui.browser
 
+import android.content.Context
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
+import androidx.webkit.WebResourceResponseCompat
+import com.testlabs.browser.domain.settings.EngineMode
+import com.testlabs.browser.domain.settings.WebViewConfig
+import com.testlabs.browser.network.CronetHolder
+import com.testlabs.browser.network.CronetHttpStack
+import com.testlabs.browser.network.OkHttpStack
+import com.testlabs.browser.network.ProxyRequest
+import com.testlabs.browser.network.UserAgentClientHintsManager
+import kotlinx.coroutines.runBlocking
+import java.util.Locale
 
 public interface NetworkProxy {
     public val stackName: String
@@ -17,13 +28,64 @@ public interface NetworkProxy {
     ): WebResourceResponse?
 }
 
-public class DefaultNetworkProxy : NetworkProxy {
-    override val stackName: String = "Default"
+public class DefaultNetworkProxy(
+    context: Context,
+    private val config: WebViewConfig,
+    private val uaProvider: UAProvider,
+    private val chManager: UserAgentClientHintsManager
+) : NetworkProxy {
+    private val httpStack = if (config.engineMode == EngineMode.Cronet) {
+        val ua = config.customUserAgent ?: uaProvider.userAgent(desktop = config.desktopMode)
+        val engine = CronetHolder.getEngine(context, ua)
+        if (engine != null) CronetHttpStack(engine, uaProvider, chManager)
+        else OkHttpStack(uaProvider, chManager)
+    } else {
+        OkHttpStack(uaProvider, chManager)
+    }
+
+    override val stackName: String = httpStack.name
 
     override fun interceptRequest(
         request: WebResourceRequest,
         userAgent: String,
         acceptLanguage: String,
         proxyEnabled: Boolean
-    ): WebResourceResponse? = null
+    ): WebResourceResponse? {
+        if (!proxyEnabled) return null
+
+        val headers = LinkedHashMap<String, String>()
+        request.requestHeaders.forEach { (k, v) ->
+            val lk = k.lowercase(Locale.US)
+            if (config.suppressXRequestedWith && lk == "x-requested-with") return@forEach
+            when (lk) {
+                "user-agent" -> headers["User-Agent"] = userAgent
+                "accept-language" -> headers["Accept-Language"] = acceptLanguage
+                "sec-ch-ua", "sec-ch-ua-mobile", "sec-ch-ua-platform" -> {}
+                else -> headers[k] = v
+            }
+        }
+        headers["User-Agent"] = userAgent
+        headers["Accept-Language"] = acceptLanguage
+
+        val major = Regex("Chrome/(\\d+)").find(userAgent)?.groupValues?.get(1) ?: "99"
+        val hints = chManager.lowEntropyUaHints(major)
+        headers["Sec-CH-UA"] = hints["sec-ch-ua"]!!
+        headers["Sec-CH-UA-Mobile"] = hints["sec-ch-ua-mobile"]!!
+        headers["Sec-CH-UA-Platform"] = hints["sec-ch-ua-platform"]!!
+
+        val proxyReq = ProxyRequest(
+            url = request.url.toString(),
+            method = request.method,
+            headers = headers
+        )
+
+        val resp = runBlocking { httpStack.execute(proxyReq) }
+        val headerMap = resp.headers.mapValues { it.value.joinToString(",") }
+        val contentType = headerMap["Content-Type"] ?: "application/octet-stream"
+        val mime = contentType.substringBefore(';')
+        val charset = contentType.substringAfter("charset=", "")
+            .ifEmpty { null }
+        val webResp = WebResourceResponseCompat.create(mime, charset, resp.statusCode, resp.reasonPhrase, headerMap, resp.body)
+        return webResp
+    }
 }

--- a/app/src/main/java/com/testlabs/browser/ui/browser/WebViewHost.kt
+++ b/app/src/main/java/com/testlabs/browser/ui/browser/WebViewHost.kt
@@ -220,6 +220,12 @@ private fun WebView.applyConfig(
     s.useWideViewPort = true
     s.loadWithOverviewMode = true
 
+    if (config.suppressXRequestedWith &&
+        WebViewFeature.isFeatureSupported(WebViewFeature.REQUESTED_WITH_HEADER_CONTROL)
+    ) {
+        WebSettingsCompat.setRequestedWithHeaderOriginAllowList(s, emptySet())
+    }
+
     val ua = config.customUserAgent ?: uaProvider.userAgent(desktop = config.desktopMode)
     s.userAgentString = ua
 


### PR DESCRIPTION
## Summary
- Shape UA-CH values centrally and expose low-entropy Chrome hints
- Add engine and header suppression flags to WebView configuration and persist them
- Route WebView requests through a proxy that strips `X-Requested-With`, injects UA-CH, and prefers Cronet with QUIC disabled

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew lint` *(fails: SDK location not found)*
- `curl -I https://tls.peet.ws/` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9968ce8c8325a03089fe2de13806