### PR TITLE
Align UA-CH and header sanitization with Chrome

### DIFF
--- a/app/src/main/java/com/testlabs/browser/di/CoreModule.kt
+++ b/app/src/main/java/com/testlabs/browser/di/CoreModule.kt
@@ -19,5 +19,5 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(na
 public val coreModule: Module = module {
     single { androidContext().dataStore }
     single { DeveloperSettings() }
-    single { UserAgentClientHintsManager(androidContext()) }
+    single { UserAgentClientHintsManager(get()) }
 }

--- a/app/src/main/java/com/testlabs/browser/network/CronetHolder.kt
+++ b/app/src/main/java/com/testlabs/browser/network/CronetHolder.kt
@@ -53,10 +53,19 @@ public object CronetHolder {
 
     private fun createEngine(context: Context, userAgent: String): CronetEngine? {
         fun createBuilder(): CronetEngine.Builder {
+            val experimental =
+                """{
+                  "disable_certificate_compression": false,
+                  "enable_certificate_compression_brotli": true,
+                  "enable_encrypted_client_hello": false,
+                  "enable_tls13_early_data": false,
+                  "enable_tls13_kyber": false
+                }""".trimIndent()
             return CronetEngine.Builder(context)
                 .enableHttp2(true)
                 .enableQuic(false)
                 .enableBrotli(true)
+                .setExperimentalOptions(experimental)
                 .apply {
                     
                     try {
@@ -70,7 +79,7 @@ public object CronetHolder {
                         Log.d(TAG, "ZSTD compression not available: ${e.javaClass.simpleName}")
                     }
                 }
-                .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_IN_MEMORY, 20L * 1024 * 1024) 
+                .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_IN_MEMORY, 20L * 1024 * 1024)
                 .setUserAgent(userAgent)
                 .setThreadPriority(Thread.NORM_PRIORITY)
         }

--- a/app/src/main/java/com/testlabs/browser/network/OkHttpClientProvider.kt
+++ b/app/src/main/java/com/testlabs/browser/network/OkHttpClientProvider.kt
@@ -6,6 +6,7 @@ package com.testlabs.browser.network
 
 import okhttp3.Dns
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.dnsoverhttps.DnsOverHttps
@@ -18,12 +19,12 @@ import java.util.concurrent.TimeUnit
 public object OkHttpClientProvider {
     @Volatile private var cached: OkHttpClient? = null
 
-    public val client: OkHttpClient
-        get() = cached ?: synchronized(this) {
-            cached ?: build().also { cached = it }
+    public fun client(uaCh: UserAgentClientHintsManager): OkHttpClient =
+        cached ?: synchronized(this) {
+            cached ?: build(uaCh).also { cached = it }
         }
 
-    private fun build(): OkHttpClient {
+    private fun build(uaCh: UserAgentClientHintsManager): OkHttpClient {
         val base = OkHttpClient.Builder()
             .retryOnConnectionFailure(true)
             .followRedirects(true)
@@ -32,6 +33,7 @@ public object OkHttpClientProvider {
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)
             .protocols(listOf(Protocol.HTTP_2, Protocol.HTTP_1_1))
+            .addInterceptor(uaParityInterceptor(uaCh))
             .build()
 
         val dohCloudflare = DnsOverHttps.Builder()
@@ -65,5 +67,27 @@ public object OkHttpClientProvider {
         return base.newBuilder()
             .dns(multiDns)
             .build()
+    }
+
+    private fun uaParityInterceptor(uaCh: UserAgentClientHintsManager) = Interceptor { chain ->
+        val original = chain.request()
+        val builder = original.newBuilder()
+
+        // Remove X-Requested-With
+        original.headers.names()
+            .filter { it.equals("x-requested-with", ignoreCase = true) }
+            .forEach { builder.removeHeader(it) }
+
+        // Remove any existing UA-CH headers
+        listOf("sec-ch-ua", "sec-ch-ua-mobile", "sec-ch-ua-platform").forEach { h ->
+            original.headers.names()
+                .firstOrNull { it.equals(h, ignoreCase = true) }
+                ?.let { builder.removeHeader(it) }
+        }
+
+        // Inject canonical UA-CH
+        uaCh.asMap(isMobile = true).forEach { (k, v) -> builder.addHeader(k, v) }
+
+        chain.proceed(builder.build())
     }
 }

--- a/app/src/main/java/com/testlabs/browser/network/OkHttpStack.kt
+++ b/app/src/main/java/com/testlabs/browser/network/OkHttpStack.kt
@@ -19,7 +19,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
 public class OkHttpStack(
     private val uaProvider: UAProvider,
     private val chManager: UserAgentClientHintsManager,
-    private val client: OkHttpClient = OkHttpClientProvider.client
+    private val client: OkHttpClient = OkHttpClientProvider.client(chManager)
 ) : HttpStack {
 
     override val name: String = "okhttp"
@@ -35,8 +35,7 @@ public class OkHttpStack(
         headers["User-Agent"] = ua
         val acceptLang = headers["Accept-Language"] ?: "en-US,en;q=0.9"
         headers["Accept-Language"] = acceptLang
-        val major = Regex("Chrome/(\\d+)").find(ua)?.groupValues?.get(1) ?: "99"
-        val hints = chManager.lowEntropyUaHints(major)
+        val hints = chManager.asMap(isMobile = true)
         headers["Sec-CH-UA"] = hints["sec-ch-ua"]!!
         headers["Sec-CH-UA-Mobile"] = hints["sec-ch-ua-mobile"]!!
         headers["Sec-CH-UA-Platform"] = hints["sec-ch-ua-platform"]!!

--- a/app/src/main/java/com/testlabs/browser/network/UserAgentClientHintsManager.kt
+++ b/app/src/main/java/com/testlabs/browser/network/UserAgentClientHintsManager.kt
@@ -1,132 +1,35 @@
-/**
- * Author: Lorenzo Suarez
- * Date: 09/06/2025
- */
 package com.testlabs.browser.network
 
-import android.content.Context
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.stringSetPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
-import java.util.concurrent.ConcurrentHashMap
+import com.testlabs.browser.ui.browser.VersionProvider
 
 /**
- * UA-CH (Client Hints) management
- * Send high-entropy hints only to origins that previously advertised them via Accept-CH.
- * Persist per-origin flags in DataStore.
+ * Builds canonical User-Agent Client Hint headers that mirror Chrome for Android.
+ *
+ * The returned values are raw strings and must not be pre-escaped. Quote
+ * characters are included directly so underlying HTTP stacks can transmit them
+ * unchanged.
  */
-public class UserAgentClientHintsManager(private val context: Context) {
+class UserAgentClientHintsManager(
+    private val versionProvider: VersionProvider
+) {
+    /** Return Chrome major from the current User-Agent. */
+    private fun chromeMajor(): String = versionProvider.major()
 
-    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "ua_ch_prefs")
+    /** Exact Sec-CH-UA header value. */
+    fun secChUa(): String =
+        "\"Not;A=Brand\";v=\"99\", \"Google Chrome\";v=\"${chromeMajor()}\", \"Chromium\";v=\"${chromeMajor()}\""
 
-    
-    private val allowedHints = ConcurrentHashMap<String, Set<String>>()
+    /** Whether the browser is on a mobile device. */
+    fun secChUaMobile(isMobile: Boolean = true): String = if (isMobile) "?1" else "?0"
 
-    public companion object {
-        private val ACCEPT_CH_KEY = stringSetPreferencesKey("accept_ch_origins")
+    /** Platform identifier for Android devices. */
+    fun secChUaPlatform(): String = "\"Android\""
 
-        
-        private val HIGH_ENTROPY_HINTS = setOf(
-            "sec-ch-ua-arch",
-            "sec-ch-ua-bitness",
-            "sec-ch-ua-model",
-            "sec-ch-ua-platform-version",
-            "sec-ch-ua-full-version-list"
-        )
-    }
-
-    /**
-     * Returns the default low-entropy UA-CH headers that mimic Chrome Mobile.
-     * The provided [majorVersion] must match the major version used in the User-Agent string.
-     */
-    public fun lowEntropyUaHints(majorVersion: String): Map<String, String> {
-        val ua = "\"Not;A=Brand\";v=\"99\", \"Google Chrome\";v=\"$majorVersion\", \"Chromium\";v=\"$majorVersion\""
-        return mapOf(
-            "sec-ch-ua" to ua,
-            "sec-ch-ua-mobile" to "?1",
-            "sec-ch-ua-platform" to "\"Android\""
-        )
-    }
-
-    /**
-     * Check if a high-entropy hint is allowed for the given origin
-     */
-    public suspend fun isHighEntropyAllowed(origin: String, hintName: String): Boolean {
-        if (hintName.lowercase() !in HIGH_ENTROPY_HINTS) {
-            return true 
-        }
-
-        
-        val cachedHints = allowedHints[origin]
-        if (cachedHints != null) {
-            return hintName.lowercase() in cachedHints
-        }
-
-        
-        val allowedForOrigin = loadAllowedHints(origin)
-        allowedHints[origin] = allowedForOrigin
-
-        return hintName.lowercase() in allowedForOrigin
-    }
-
-    /**
-     * Process Accept-CH header from response and update allowed hints for origin
-     */
-    public suspend fun processAcceptCH(origin: String, acceptChHeader: String?) {
-        if (acceptChHeader.isNullOrBlank()) return
-
-        val requestedHints = acceptChHeader
-            .split(",")
-            .map { it.trim().lowercase() }
-            .filter { it in HIGH_ENTROPY_HINTS }
-            .toSet()
-
-        if (requestedHints.isNotEmpty()) {
-            
-            allowedHints[origin] = requestedHints
-
-            
-            saveAllowedHints(origin, requestedHints)
-        }
-    }
-
-    private suspend fun loadAllowedHints(origin: String): Set<String> {
-        return try {
-            val originKey = stringSetPreferencesKey("hints_$origin")
-            context.dataStore.data.map { preferences ->
-                preferences[originKey] ?: emptySet()
-            }.first()
-        } catch (e: Exception) {
-            emptySet()
-        }
-    }
-
-    private suspend fun saveAllowedHints(origin: String, hints: Set<String>) {
-        try {
-            val originKey = stringSetPreferencesKey("hints_$origin")
-            context.dataStore.edit { preferences ->
-                preferences[originKey] = hints
-            }
-        } catch (e: Exception) {
-            
-        }
-    }
-
-    /**
-     * Clear all stored UA-CH permissions (for debugging/reset)
-     */
-    public suspend fun clearAllHints() {
-        try {
-            context.dataStore.edit { preferences ->
-                preferences.clear()
-            }
-            allowedHints.clear()
-        } catch (e: Exception) {
-            
-        }
-    }
+    /** Convenience helper returning the standard UA-CH map. */
+    fun asMap(isMobile: Boolean = true): Map<String, String> = mapOf(
+        "sec-ch-ua" to secChUa(),
+        "sec-ch-ua-mobile" to secChUaMobile(isMobile),
+        "sec-ch-ua-platform" to secChUaPlatform()
+    )
 }
+

--- a/app/src/main/java/com/testlabs/browser/ui/browser/AndroidVersionProvider.kt
+++ b/app/src/main/java/com/testlabs/browser/ui/browser/AndroidVersionProvider.kt
@@ -17,7 +17,9 @@ public class AndroidVersionProvider(private val context: Context) : VersionProvi
         return packageVersion("com.google.android.webview") ?: "0.0.0.0"
     }
 
-    override fun chromeMajor(): Int = chromeFullVersion().substringBefore('.').toIntOrNull() ?: 0
+    private val major: Int by lazy { chromeFullVersion().substringBefore('.').toIntOrNull() ?: 0 }
+
+    override fun chromeMajor(): Int = major
 
     override fun deviceModel(): String = Build.MODEL ?: "Android"
 

--- a/app/src/main/java/com/testlabs/browser/ui/browser/VersionProvider.kt
+++ b/app/src/main/java/com/testlabs/browser/ui/browser/VersionProvider.kt
@@ -15,4 +15,7 @@ public interface VersionProvider {
 
     /** Device model reported in the UA string. */
     public fun deviceModel(): String
+
+    /** Chrome major version as a string for convenience. */
+    public fun major(): String = chromeMajor().toString()
 }


### PR DESCRIPTION
## Summary
- generate Chrome-style UA-CH without manual escaping
- defensively strip `X-Requested-With` and inject canonical UA-CH in proxy and stacks
- configure Cronet for h2 parity and disable QUIC experiments

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bca0bed5e08325b58eaa2ccd195fdf