### PR TITLE
feat: control X-Requested-With header via WebKit

### DIFF
--- a/app/src/main/java/com/testlabs/browser/ui/browser/BrowserScreen.kt
+++ b/app/src/main/java/com/testlabs/browser/ui/browser/BrowserScreen.kt
@@ -168,8 +168,9 @@ public fun BrowserScreen(
 
             val headerModeString = when (mode) {
                 RequestedWithHeaderMode.ALLOW_LIST -> {
-                    val count = parseRequestedWithHeaderAllowList(state.settingsDraft.requestedWithHeaderAllowList).size
-                    "Allow-list($count)"
+                    val allow = parseRequestedWithHeaderAllowList(state.settingsDraft.requestedWithHeaderAllowList)
+                    val preview = allow.take(3).joinToString(",")
+                    "Allow-list(${allow.size}): $preview"
                 }
                 RequestedWithHeaderMode.ELIMINATED -> "Eliminated"
                 RequestedWithHeaderMode.UNKNOWN -> "Unknown"

--- a/app/src/main/java/com/testlabs/browser/ui/browser/NetworkProxy.kt
+++ b/app/src/main/java/com/testlabs/browser/ui/browser/NetworkProxy.kt
@@ -78,12 +78,6 @@ public class DefaultNetworkProxy(
     public fun normalizeHeaders(incoming: Map<String, String>): Map<String, String> {
         val sanitized = incoming.toMutableMap()
 
-        if (config.suppressXRequestedWith) {
-            sanitized.keys
-                .filter { it.equals("x-requested-with", ignoreCase = true) }
-                .forEach { sanitized.remove(it) }
-        }
-
         listOf("sec-ch-ua", "sec-ch-ua-mobile", "sec-ch-ua-platform").forEach { k ->
             sanitized.keys
                 .firstOrNull { it.equals(k, ignoreCase = true) }

--- a/app/src/main/java/com/testlabs/browser/ui/browser/ProxyValidator.kt
+++ b/app/src/main/java/com/testlabs/browser/ui/browser/ProxyValidator.kt
@@ -29,7 +29,8 @@ public object ProxyValidator {
             val detail = when (mode) {
                 RequestedWithHeaderMode.ALLOW_LIST -> {
                     val allow = WebSettingsCompat.getRequestedWithHeaderOriginAllowList(webView.settings)
-                    "Allow-list(${allow.size})"
+                    val preview = allow.take(3).joinToString(",")
+                    "Allow-list(${allow.size}): $preview"
                 }
                 RequestedWithHeaderMode.ELIMINATED -> "Eliminated"
                 RequestedWithHeaderMode.UNKNOWN -> "Unknown"

--- a/app/src/main/java/com/testlabs/browser/ui/browser/RequestedWithHeaderMode.kt
+++ b/app/src/main/java/com/testlabs/browser/ui/browser/RequestedWithHeaderMode.kt
@@ -24,13 +24,13 @@ public enum class RequestedWithHeaderMode {
 }
 
 @SuppressLint("WebViewFeature", "RequiresFeature")
-internal fun requestedWithHeaderModeOf(webView: android.webkit.WebView): RequestedWithHeaderMode =
+public fun requestedWithHeaderModeOf(webView: android.webkit.WebView): RequestedWithHeaderMode =
     runCatching {
         val allow = WebSettingsCompat.getRequestedWithHeaderOriginAllowList(webView.settings)
         if (allow.isEmpty()) RequestedWithHeaderMode.ELIMINATED else RequestedWithHeaderMode.ALLOW_LIST
     }.getOrElse { RequestedWithHeaderMode.UNKNOWN }
 
-internal fun parseRequestedWithHeaderAllowList(raw: String): Set<String> = raw
+public fun parseRequestedWithHeaderAllowList(raw: String): Set<String> = raw
     .split(',', ' ', '\n')
     .map { it.trim() }
     .filter { it.isNotEmpty() }


### PR DESCRIPTION
## Summary
- expose requested-with helpers to UI
- rely on WebKit allow list instead of stripping header in proxy
- show X-Requested-With mode and origins in diagnostics

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb029d84c8325958c9ef86f7444be